### PR TITLE
Update the 1Forge api URL to reflect upcoming changes in the 1Forge API

### DIFF
--- a/src/Service/Forge.php
+++ b/src/Service/Forge.php
@@ -13,7 +13,7 @@ use Exchanger\Exception\UnsupportedCurrencyPairException;
  */
 class Forge extends Service
 {
-    const URL = 'https://forex.1forge.com/latest/quotes?pairs=%s&api_key=%s';
+    const URL = 'https://api.1forge.com/quotes?pairs=%s&api_key=%s';
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
**Not usable before Monday, September 9th at 9AM EST**

1Forge is upgrading their infrastructure and will deactivate the current setup by October 18th, 2019.
To keep using the 1Fore REST API we simply need to replace the API URL for now.

**Original Message from 1Forge:**

> Hi {USER},
As you may have previously heard, we are releasing new APIs for 1Forge. The endpoints will be active for all customers starting Monday, September 9th at 9AM EST. We will also be updating the documentation on our website to reflect the changes below.
If you are using the REST api and are not utilizing on of our libraries, the URL change will be from:
https://forex.1forge.com/1.0.3/endpoint
to
https://api.1forge.com/endpoint
No additional changes will be required for REST customers.
For WebSocket customers who are not utilizing our library, we have eliminated HTTP Polling in favor of web socket core code. This provides a much faster and more reliable socket source. The endpoint for the WebSocket server will be changing from:
https://socket.forex.1forge.com:3000
to
https://api.1forge.com/socket
Authentication for the socket server will remain the same but again, HTTP Polling is not active since we have eliminated the Socket IO library from our operation.
We will continue operating our current servers until market close October 18th, 2019. In the coming weeks, we will be releasing breaking change versions of our APIs for PHP, Javascript, Python, Ruby, and adding a few language supports as well.
Thank you for your patience as we continue to grow our services!
Phil Switzer
1Forge